### PR TITLE
Replaces Pitbase with Altshadow's Pitbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ IF YOU WANT TO SUBMIT A NEW MAP, YOU MUST ALSO WRITE A BACKSTORY! See the [gymna
 - Props: When the fat kid uses his stun attack, all nearby prop_physics will be unfrozen and have some force added. Using frozen prop_physics can make your map more exciting.
 - General practices: Don't make areas too big and open; it makes it too easy for skinny kids to shoot the skeletons. Try to make sure there are at least two ways for skeletons to get to any area to prevent them from getting bored of running through a single doorway and dying over and over.
 - BSP filenames must start with "fatkid_" in lowercase in order for it to appear in the mapvote panel.
+- These files are added to the workshop addon, so try and keep the file size small (around 30-40mb is the limit).
 
 # Credits
 
 Programmer and official server manager: [swamponions](https://steamcommunity.com/id/swamponions/)
+
+**NEW** fatkid_pitbaseremake [AltShadow](https://steamcommunity.com/id/altshadow/)
 
 **NEW** fatkid_asylum_v1 [AltShadow](https://steamcommunity.com/id/altshadow/)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ IF YOU WANT TO SUBMIT A NEW MAP, YOU MUST ALSO WRITE A BACKSTORY! See the [gymna
 
 Programmer and official server manager: [swamponions](https://steamcommunity.com/id/swamponions/)
 
-**NEW** fatkid_pitbaseremake [AltShadow](https://steamcommunity.com/id/altshadow/)
+**NEW** fatkid_pitbase [AltShadow](https://steamcommunity.com/id/altshadow/)
 
 **NEW** fatkid_asylum_v1 [AltShadow](https://steamcommunity.com/id/altshadow/)
 

--- a/gamemodes/fatkid/gamemode/maps/pitbase/init.lua
+++ b/gamemodes/fatkid/gamemode/maps/pitbase/init.lua
@@ -1,3 +1,3 @@
 ﻿-- Copyright (C) 2021 Swamp Servers. https://github.com/swampservers/fatkid
 -- Use is subject to a restrictive license, please see: https://github.com/swampservers/fatkid/blob/master/LICENSE
-GM.BarricadeBaseHealth = 1000
+GM.BarricadeBaseHealth = 1250

--- a/gamemodes/fatkid/gamemode/maps/pitbase/sh_init.lua
+++ b/gamemodes/fatkid/gamemode/maps/pitbase/sh_init.lua
@@ -1,7 +1,7 @@
 ﻿-- Copyright (C) 2021 Swamp Servers. https://github.com/swampservers/fatkid
 -- Use is subject to a restrictive license, please see: https://github.com/swampservers/fatkid/blob/master/LICENSE
 FATKID_BACKSTORY = [[
-<h2>Welcome to PitBase (Remade).</h2>
+<h2>Welcome to PitBase.</h2>
 <p>
 </p>
 ]]

--- a/gamemodes/fatkid/gamemode/maps/pitbase/sh_init.lua
+++ b/gamemodes/fatkid/gamemode/maps/pitbase/sh_init.lua
@@ -1,7 +1,7 @@
 ﻿-- Copyright (C) 2021 Swamp Servers. https://github.com/swampservers/fatkid
 -- Use is subject to a restrictive license, please see: https://github.com/swampservers/fatkid/blob/master/LICENSE
 FATKID_BACKSTORY = [[
-<h2>Welcome to PitBase.</h2>
+<h2>Welcome to PitBase (Remade).</h2>
 <p>
 </p>
 ]]


### PR DESCRIPTION
Altshadow's pitbase now replaces the original older pitbase since we won't have both.
This map features 1250 health barricades.

For images of the map, see https://github.com/swampservers/fatkid/pull/44 